### PR TITLE
Changing the title of teaser sidebar from Element to Teaser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfix
 
 - Make Slate block work properly @tiberiuichim
+- Change the title of teaser sidebar from 'Element' to 'Teaser' @iFlameing
 
 ### Internal
 

--- a/src/components/Teaser/schema.js
+++ b/src/components/Teaser/schema.js
@@ -5,10 +5,6 @@ const messages = defineMessages({
     id: 'Source',
     defaultMessage: 'Source',
   },
-  item: {
-    id: 'Item',
-    defaultMessage: 'Item',
-  },
   imageOverride: {
     id: 'Image override',
     defaultMessage: 'Image override',
@@ -29,13 +25,17 @@ const messages = defineMessages({
     id: 'Headtitle',
     defaultMessage: 'Headtitle',
   },
+  teaser: {
+    id: 'Teaser',
+    defaultMessage: 'Teaser',
+  },
 });
 
 export const TeaserSchema = (props) => {
   const { intl } = props;
 
   return {
-    title: intl.formatMessage(messages.item),
+    title: intl.formatMessage(messages.teaser),
     fieldsets: [
       {
         id: 'default',


### PR DESCRIPTION
@tisto  screenshot

![Seite bearbeiten (3)](https://user-images.githubusercontent.com/33936987/124285481-93a54e80-db6b-11eb-9239-6dd94c848c83.jpg)
