### PR TITLE
add translation for head_title in teaser/data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - Detached mode 2.0 @tiberiuichim
 - Related slate/text styling @sneridagh
+- Add german translation for head_title in teaser/data @ThomasKindermann
 
 ## 2.0.0 (2021-05-22)
 

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -58,4 +58,4 @@ msgstr "spalten"
 
 #: components/Teaser/schema
 msgid "head_title"
-msgstr ""
+msgstr "Kopftitel"

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2021-07-06T15:19:23.677Z\n"
+"POT-Creation-Date: 2021-07-16T09:24:20.729Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -64,6 +64,6 @@ msgid "columns"
 msgstr ""
 
 #: components/Teaser/schema
-# defaultMessage: head_title
+# defaultMessage: head title
 msgid "head_title"
 msgstr ""

--- a/src/components/Teaser/schema.js
+++ b/src/components/Teaser/schema.js
@@ -23,7 +23,7 @@ const messages = defineMessages({
   },
   head_title: {
     id: 'head_title',
-    defaultMessage: 'head_title',
+    defaultMessage: 'head title',
   },
   teaser: {
     id: 'Teaser',


### PR DESCRIPTION
add english and german translation for head_title in teaser / data 

for FZJ-Internet:
https://jugit.fz-juelich.de/fzj-internet/internet/-/issues/459

