### PR TITLE
Configurable max number of columns from config

### DIFF
--- a/src/components/Grid/Edit.jsx
+++ b/src/components/Grid/Edit.jsx
@@ -151,6 +151,10 @@ class EditGrid extends Component {
 
   addNewColumn = (e) => {
     e.stopPropagation();
+    var maxNumberOfColumns =
+      config.blocks.blocksConfig.__grid.maxNumberOfColumns > 16
+        ? 16
+        : config.blocks.blocksConfig.__grid.maxNumberOfColumns;
     const type =
       getAllowedBlocks(this.props.data['@type'])?.length === 1
         ? getAllowedBlocks(this.props.data['@type'])[0]
@@ -162,7 +166,7 @@ class EditGrid extends Component {
         ...(type && { '@type': type }),
       },
     ];
-    if (this.props.data.columns.length < 4) {
+    if (this.props.data.columns.length < maxNumberOfColumns) {
       this.props.onChangeBlock(this.props.block, {
         ...this.props.data,
         columns: newColumnsState,

--- a/src/components/Grid/grid-5.svg
+++ b/src/components/Grid/grid-5.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96" height="96" version="1.1" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+ <g fill-rule="evenodd">
+  <rect width="96" height="96" rx="3" fill="#9FD1E5"/>
+  <g transform="matrix(.80193 0 0 1 24.044 22)" fill="#fff" opacity=".9">
+   <rect x="42" width="18" height="53"/>
+   <rect x="63" width="18" height="53"/>
+   <rect width="18" height="53"/>
+   <rect x="21" width="18" height="53"/>
+   <rect x="-21.024" width="18" height="53"/>
+  </g>
+ </g>
+</svg>

--- a/src/components/Grid/grid-6.svg
+++ b/src/components/Grid/grid-6.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96" height="96" version="1.1" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+ <g fill-rule="evenodd">
+  <rect width="96" height="96" rx="3" fill="#9FD1E5"/>
+  <g transform="matrix(.66542 0 0 1 35.101 22)" fill="#fff" opacity=".9">
+   <rect x="42" width="18" height="53"/>
+   <rect x="63" width="18" height="53"/>
+   <rect width="18" height="53"/>
+   <rect x="21" width="18" height="53"/>
+   <rect x="-21.024" width="18" height="53"/>
+   <rect x="-42.165" width="18" height="53"/>
+  </g>
+ </g>
+</svg>

--- a/src/components/Grid/grid-more.svg
+++ b/src/components/Grid/grid-more.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96" height="96" version="1.1" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+ <g fill-rule="evenodd">
+  <rect width="96" height="96" rx="3" fill="#9FD1E5"/>
+  <g transform="matrix(.80193 0 0 1 24.044 22)" fill="#fff" opacity=".9">
+   <rect x="60.506" width="18" height="53"/>
+   <rect x="26.042" y="23.227" width="7.9112" height="6.5322" rx="3.9556" ry="3.2661" stroke-width=".23274"/>
+   <rect x="-18.53" width="18" height="53"/>
+   <rect x="9.3287" y="23.216" width="7.9112" height="6.5322" rx="3.9556" ry="3.2661" stroke-width=".23274"/>
+   <rect x="42.752" y="23.216" width="7.9112" height="6.5322" rx="3.9556" ry="3.2661" stroke-width=".23274"/>
+  </g>
+ </g>
+</svg>

--- a/src/components/Grid/templates.js
+++ b/src/components/Grid/templates.js
@@ -5,6 +5,9 @@ import gridTemplate1 from './grid-1.svg';
 import gridTemplate2 from './grid-2.svg';
 import gridTemplate3 from './grid-3.svg';
 import gridTemplate4 from './grid-4.svg';
+import gridTemplate5 from './grid-5.svg';
+import gridTemplate6 from './grid-6.svg';
+import gridTemplateMore from './grid-more.svg';
 
 const messages = defineMessages({
   column: {
@@ -17,74 +20,111 @@ const messages = defineMessages({
   },
 });
 
+const getColumns = (numberOfColumns, type) => {
+  return [...Array(numberOfColumns).keys()].map((i) => {
+    return {
+      id: uuid(),
+      ...(type && { '@type': type }),
+    };
+  });
+};
+
 const templates = (type) => (intl) => [
   {
     image: gridTemplate1,
     id: 'gridtemplateone',
     title: `1 ${intl.formatMessage(messages.column)}`,
-    columns: [
-      {
-        id: uuid(),
-        ...(type && { '@type': type }),
-      },
-    ],
+    columns: getColumns(1, type),
   },
   {
     image: gridTemplate2,
     id: 'gridtemplatetwo',
     title: `2 ${intl.formatMessage(messages.columns)}`,
-    columns: [
-      {
-        id: uuid(),
-        ...(type && { '@type': type }),
-      },
-      {
-        id: uuid(),
-        ...(type && { '@type': type }),
-      },
-    ],
+    columns: getColumns(2, type),
   },
   {
     image: gridTemplate3,
     id: 'gridtemplatethree',
     title: `3 ${intl.formatMessage(messages.columns)}`,
-    columns: [
-      {
-        id: uuid(),
-        ...(type && { '@type': type }),
-      },
-      {
-        id: uuid(),
-        ...(type && { '@type': type }),
-      },
-      {
-        id: uuid(),
-        ...(type && { '@type': type }),
-      },
-    ],
+    columns: getColumns(3, type),
   },
   {
     image: gridTemplate4,
     id: 'gridtemplatefour',
     title: `4 ${intl.formatMessage(messages.columns)}`,
-    columns: [
-      {
-        id: uuid(),
-        ...(type && { '@type': type }),
-      },
-      {
-        id: uuid(),
-        ...(type && { '@type': type }),
-      },
-      {
-        id: uuid(),
-        ...(type && { '@type': type }),
-      },
-      {
-        id: uuid(),
-        ...(type && { '@type': type }),
-      },
-    ],
+    columns: getColumns(4, type),
+  },
+  {
+    image: gridTemplate5,
+    id: 'gridtemplatefive',
+    title: `5 ${intl.formatMessage(messages.columns)}`,
+    columns: getColumns(5, type),
+  },
+  {
+    image: gridTemplate6,
+    id: 'gridtemplatesix',
+    title: `6 ${intl.formatMessage(messages.columns)}`,
+    columns: getColumns(6, type),
+  },
+  {
+    image: gridTemplateMore,
+    id: 'gridtemplateseven',
+    title: `7 ${intl.formatMessage(messages.columns)}`,
+    columns: getColumns(7, type),
+  },
+  {
+    image: gridTemplateMore,
+    id: 'gridtemplateseight',
+    title: `8 ${intl.formatMessage(messages.columns)}`,
+    columns: getColumns(8, type),
+  },
+  {
+    image: gridTemplateMore,
+    id: 'gridtemplatesnine',
+    title: `9 ${intl.formatMessage(messages.columns)}`,
+    columns: getColumns(9, type),
+  },
+  {
+    image: gridTemplateMore,
+    id: 'gridtemplatesten',
+    title: `10 ${intl.formatMessage(messages.columns)}`,
+    columns: getColumns(10, type),
+  },
+  {
+    image: gridTemplateMore,
+    id: 'gridtemplatesteleven',
+    title: `11 ${intl.formatMessage(messages.columns)}`,
+    columns: getColumns(11, type),
+  },
+  {
+    image: gridTemplateMore,
+    id: 'gridtemplatestwelve',
+    title: `12 ${intl.formatMessage(messages.columns)}`,
+    columns: getColumns(12, type),
+  },
+  {
+    image: gridTemplateMore,
+    id: 'gridtemplathirteen',
+    title: `13 ${intl.formatMessage(messages.columns)}`,
+    columns: getColumns(13, type),
+  },
+  {
+    image: gridTemplateMore,
+    id: 'gridtemplatesfourteen',
+    title: `14 ${intl.formatMessage(messages.columns)}`,
+    columns: getColumns(14, type),
+  },
+  {
+    image: gridTemplateMore,
+    id: 'gridtemplatesfifteen',
+    title: `15 ${intl.formatMessage(messages.columns)}`,
+    columns: getColumns(15, type),
+  },
+  {
+    image: gridTemplateMore,
+    id: 'gridtemplatessixteen',
+    title: `16 ${intl.formatMessage(messages.columns)}`,
+    columns: getColumns(16, type),
   },
 ];
 

--- a/src/components/TemplateChooser/TemplateChooser.jsx
+++ b/src/components/TemplateChooser/TemplateChooser.jsx
@@ -1,21 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { Button, Grid, Message } from 'semantic-ui-react';
+import { Button, Grid, Message, Image } from 'semantic-ui-react';
+import config from '@plone/volto/registry';
 
 const TemplateChooser = ({ templates, onSelectTemplate }) => {
   const intl = useIntl();
+  var maxNumberOfColumns = config.blocks.blocksConfig.__grid.maxNumberOfColumns;
+  var selectableTemplates = templates(intl).filter(
+    (template) => template.columns.length < maxNumberOfColumns + 1,
+  );
   return (
     <div className="template-chooser">
       <Message>
-        <Grid columns={templates(intl).length}>
-          {templates(intl).map((template, index) => (
+        <Grid
+          columns={
+            selectableTemplates.length < 9 ? selectableTemplates.length : 8
+          }
+        >
+          {selectableTemplates.map((template, index) => (
             <Grid.Column key={template.id}>
               <Button
                 className="template-chooser-item"
                 onClick={() => onSelectTemplate(index)}
               >
-                <img src={template.image} alt="" />
+                <Image src={template.image} alt="" />
                 <div className="template-chooser-title">
                   {intl.formatMessage({
                     id: template.id,

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ const customBlocks = {
       addPermission: [],
       view: [],
     },
+    maxNumberOfColumns: 4,
     gridAllowedBlocks: ['teaser', 'image', 'listing', 'slate', 'text'],
   },
   teaserGrid: {


### PR DESCRIPTION
We have a use case for a client to increase a number of colums in a grid.
So, we have modified this block to set the maximum number of columns from the configuration instead of a fixed number of columns set to four.

In addition to that, we have added the templates svg files from 5 to 16 because Semantic have a 16 column grid and we think it's enough :smile: 