### PR TITLE
Include image_scales when fetching items for the teaser block

### DIFF
--- a/src/components/Teaser/schema.js
+++ b/src/components/Teaser/schema.js
@@ -55,6 +55,7 @@ export const TeaserSchema = (props) => {
           'Description',
           'hasPreviewImage',
           'image_field',
+          'image_scales',
           '@type',
           'effective',
           'getObjSize',


### PR DESCRIPTION
(needed for rendering teasers when using preview_image_link)