### PR TITLE
Fix image height when height property is added (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix image height when height property is added (#277) @reebalazs
+
 ### Internal
 
 ## 5.0.0 (2022-09-02)

--- a/cypress/integration/blocks.js
+++ b/cypress/integration/blocks.js
@@ -33,6 +33,9 @@ context('Blocks Acceptance Tests', () => {
     });
 
     it('As editor I can add a Grid', function () {
+      cy.intercept('PATCH', '/**/document').as('edit');
+      cy.intercept('GET', '/**/document').as('content');
+
       cy.get('.block.inner.text .public-DraftEditor-content').click();
       cy.get('.button .block-add-button').click({ force: true });
       cy.get('.blocks-chooser .mostUsed .button.__grid').click();
@@ -52,6 +55,8 @@ context('Blocks Acceptance Tests', () => {
       );
 
       cy.get('#toolbar-save').click();
+      cy.wait('@edit');
+      cy.wait('@content');
 
       cy.findByText('Colorless green ideas sleep furiously.');
 
@@ -71,6 +76,8 @@ context('Blocks Acceptance Tests', () => {
       ).click();
       cy.get('[aria-label="Select My Page"]').dblclick();
       cy.get('#toolbar-save').click();
+      cy.wait('@edit');
+      cy.wait('@content');
 
       cy.get('.block.__grid').findByText('My Page');
     });

--- a/src/theme/styles.less
+++ b/src/theme/styles.less
@@ -214,7 +214,7 @@
 
     img {
       max-width: 300px;
-      // height: auto;  // this is not critical and breaks cypress tests
+      height: auto;
       align-self: center;
     }
   }

--- a/src/theme/styles.less
+++ b/src/theme/styles.less
@@ -214,6 +214,7 @@
 
     img {
       max-width: 300px;
+      // height: auto;  // this is not critical and breaks cypress tests
       align-self: center;
     }
   }
@@ -228,6 +229,7 @@
 
     img {
       max-width: 100%;
+      height: auto;
     }
   }
 }


### PR DESCRIPTION
In this case height: auto is needed from css otherwise the image will have a distorted aspect ratio.