### PR TITLE
Update BlockRenderer View/Edit to use blocksConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Bugfix
 
+- Update `BlockRenderer` component to point `EditBlock`/`ViewBlock` at `blocksConfig.edit`/`blocksConfig.view` when available @danalvrz
+
 ### Internal
 
 - Add new `headline` CSS class in teaser `head_title` @sneridagh

--- a/src/components/BlockRenderer/BlockRenderer.jsx
+++ b/src/components/BlockRenderer/BlockRenderer.jsx
@@ -36,7 +36,7 @@ BlockRenderer.propTypes = {
   block: PropTypes.string.isRequired,
   onChangeBlock: PropTypes.func,
   data: PropTypes.objectOf(PropTypes.any).isRequired,
-  blocksConfig: PropTypes.objectOf(PropTypes.any).isRequired,
+  blocksConfig: PropTypes.objectOf(PropTypes.any),
 };
 
 BlockRenderer.defaultProps = {

--- a/src/components/BlockRenderer/BlockRenderer.jsx
+++ b/src/components/BlockRenderer/BlockRenderer.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import config from '@plone/volto/registry';
 import withObjectBrowser from '@plone/volto/components/manage/Sidebar/ObjectBrowser';
 
 /**
@@ -15,8 +16,10 @@ function BlockRenderer(props) {
     return null;
   }
 
-  const EditBlock = blocksConfig[type].edit;
-  const ViewBlock = blocksConfig[type].view;
+  const EditBlock =
+    blocksConfig?.[type]?.edit || config.blocks.blocksConfig[type].edit;
+  const ViewBlock =
+    blocksConfig?.[type]?.view || config.blocks.blocksConfig[type].view;
 
   if (!edit) {
     return <ViewBlock {...props} detached onChangeBlock={() => {}} />;
@@ -33,6 +36,7 @@ BlockRenderer.propTypes = {
   block: PropTypes.string.isRequired,
   onChangeBlock: PropTypes.func,
   data: PropTypes.objectOf(PropTypes.any).isRequired,
+  blocksConfig: PropTypes.objectOf(PropTypes.any).isRequired,
 };
 
 BlockRenderer.defaultProps = {

--- a/src/components/BlockRenderer/BlockRenderer.jsx
+++ b/src/components/BlockRenderer/BlockRenderer.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import config from '@plone/volto/registry';
 import withObjectBrowser from '@plone/volto/components/manage/Sidebar/ObjectBrowser';
 
 /**
@@ -9,15 +8,15 @@ import withObjectBrowser from '@plone/volto/components/manage/Sidebar/ObjectBrow
  * @extends Component
  */
 function BlockRenderer(props) {
-  const { edit, type } = props;
+  const { edit, type, blocksConfig } = props;
 
   if (!type) {
     // We could have an empty block, although should be handled somewhere else
     return null;
   }
 
-  const EditBlock = config.blocks.blocksConfig[type].edit;
-  const ViewBlock = config.blocks.blocksConfig[type].view;
+  const EditBlock = blocksConfig[type].edit;
+  const ViewBlock = blocksConfig[type].view;
 
   if (!edit) {
     return <ViewBlock {...props} detached onChangeBlock={() => {}} />;


### PR DESCRIPTION
- Added `blocksConfig` to fetched list from `props`.
- Updated `EditBlock` & `ViewBlock` to use `blocksConfig` view/edit, when available.