### PR TITLE
Fix teaser preview image override in teaser block

### DIFF
--- a/news/90.bugfix
+++ b/news/90.bugfix
@@ -1,0 +1,1 @@
+Fix image override in teaser block @iFlameing

--- a/src/components/Teaser/DefaultBody.jsx
+++ b/src/components/Teaser/DefaultBody.jsx
@@ -59,11 +59,7 @@ const TeaserDefaultTemplate = (props) => {
             <div className="grid-teaser-item default">
               {(href.hasPreviewImage || href.image_field || image) && (
                 <div className="grid-image-wrapper">
-                  <Image
-                    src={hasImageComponent ? href : defaultImageSrc}
-                    alt=""
-                    loading="lazy"
-                  />
+                  <Image src={defaultImageSrc} alt="" loading="lazy" />
                 </div>
               )}
               <div className="content">


### PR DESCRIPTION
Steps to reproduce the issue.

1. Add a teaser lock and select the content
2. Override the image by selection.

It will not override the image persent in the page.