### PR TITLE
Add Slate block wrapper

### DIFF
--- a/news/92.bugfix
+++ b/news/92.bugfix
@@ -1,0 +1,1 @@
+Add a wrapper to the ViewBlock when the in-grid block type is slate. @danalvrz

--- a/src/components/BlockRenderer/BlockRenderer.jsx
+++ b/src/components/BlockRenderer/BlockRenderer.jsx
@@ -22,7 +22,13 @@ function BlockRenderer(props) {
     blocksConfig?.[type]?.view || config.blocks.blocksConfig[type].view;
 
   if (!edit) {
-    return <ViewBlock {...props} detached onChangeBlock={() => {}} />;
+    return type === 'slate' ? (
+      <div className="block slate">
+        <ViewBlock {...props} detached onChangeBlock={() => {}} />
+      </div>
+    ) : (
+      <ViewBlock {...props} detached onChangeBlock={() => {}} />
+    );
   }
   if (edit) {
     return <EditBlock {...props} detached index={0} />;


### PR DESCRIPTION
Added a `div` wrapper to the `ViewBlock` when the block type is `slate`, to improve styles implementation.